### PR TITLE
Fix inconsistency between "review" and "reviews"

### DIFF
--- a/data/session.yml
+++ b/data/session.yml
@@ -162,7 +162,7 @@ hanachin:
 
     Do you conduct code reviews?
 
-    In this session, in order to achieve "no code review", I will talk on the following topics.
+    In this session, in order to achieve "no code reviews", I will talk on the following topics.
 
     * The things you do in the code reviews.
     * Why you do the things in the code reviews.


### PR DESCRIPTION
以前に翻訳したとき、一箇所だけ review になってたので、表記ゆれをなくします。