### PR TITLE
add an information page for speaker link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ https://railsdm.github.io/
 ## Build the site
 
     bundle exec middleman build
+    
+## Information for speakers
+
+https://gist.github.com/yhirano55/4a8e0b56e3627be54da05385ce6103c8
 
 ## LICENSE
 


### PR DESCRIPTION
登壇者向けの情報への導線が入稿時のgoogleフォーム以外に見当たらなかったのでreadmeにも書いてみました